### PR TITLE
Fix docs and CounTally tests

### DIFF
--- a/ExApps/CounTally/create_test.py
+++ b/ExApps/CounTally/create_test.py
@@ -1,10 +1,11 @@
 import os
 
 # Get the directory of the script
-test_file_path = os.path.dirname(os.path.abspath(__file__))
+dir_path = os.path.dirname(os.path.abspath(__file__))
+file_path = os.path.join(dir_path, "test_file.txt")
 
-# Create and write to the file
-with open(test_file_path, 'w') as test_file:
-    test_file.write('Hello, this is a test file!')
-
-input(f'Test file created at: {test_file_path}')
+# Create and write to the file when run directly
+if __name__ == "__main__":
+    with open(file_path, 'w') as test_file:
+        test_file.write('Hello, this is a test file!')
+    input(f'Test file created at: {file_path}')

--- a/ExApps/CounTally/test_coun_tally.py
+++ b/ExApps/CounTally/test_coun_tally.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(__file__))
+from CounTally import generate_new_count_html, generate_historical_html
+
+
+def test_generate_new_count_html_contains_tally(tmp_path):
+    html = generate_new_count_html(5)
+    assert "<span id=\"count\">5</span>" in html
+
+
+def test_generate_historical_html_contains_rows(tmp_path):
+    data = [
+        {"Date": "2023-01-01", "Counter Name": "A", "Tally": "2", "Notes": "x"},
+        {"Date": "2023-01-02", "Counter Name": "B", "Tally": "3", "Notes": "y"},
+    ]
+    html = generate_historical_html(data)
+    assert "<td>2023-01-01</td>" in html
+    assert "<td>A</td>" in html
+    assert "<td>3</td>" in html

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SApps is a suite of standalone HTML applications that can perform various tasks 
 ## No Frameworks, No Libraries, No Dependencies, No Problem
 These applications are designed to be as lightweight as possible. They do not use any frameworks, libraries, or dependencies. They are designed to be entirely self-contained and portable. They should be able to be used on any computer, from a USB drive, and should not require any installation or configuration.
 
-There is some customisation that can be done - but this should be a one time think and should not require any further configuration.
+There is some customisation that can be done - but this should be a one time thing and should not require any further configuration.
 
 ## Quick Start
 1. Download the latest release
@@ -49,30 +49,30 @@ There is some customisation that can be done - but this should be a one time thi
 ### Writing & Documentation
 | App | Description | Status |
 |-----|-------------|---------|
-| [HTMLWriter](HTMLWriter/README.md) | Distraction-free writing environment | Stable |
-| [Journaller](Journaller/README.md) | Journal entry management and export | Stable |
-| [Postage](Postage/README.md) | Markdown to HTML converter | Stable |
+| [HTMLWriter](HTMLWriter/HTMLWriter - README.md) | Distraction-free writing environment | Stable |
+| [Journaller](Journaller/Journaller - README.md) | Journal entry management and export | Stable |
+| [Postage](Postage/Postage - README.md) | Markdown to HTML converter | Stable |
 
 ### Productivity
 | App | Description | Status |
 |-----|-------------|---------|
-| [HTMLToDo](HTMLToDo/README.md) | Task management system | Stable |
-| [HTMLKanban](HTMLKanban/README.md) | Visual project management | Beta |
-| [WT](WT/README.md) | Form data to CSV exporter | Stable |
+| [HTMLToDo](HTMLToDo/HTMLToDo - README.md) | Task management system | Stable |
+| [HTMLKanban](HTMLKanban/HTMLKanban - README.md) | Visual project management | Beta |
+| [WT](WT/WT - README.md) | Form data to CSV exporter | Stable |
 
 ### Creative Tools
 | App | Description | Status |
 |-----|-------------|---------|
-| [JPrompt](JPrompt/README.md) | Journal prompt generator | Stable |
-| [OSlogan](OSlogan/README.md) | Random slogan generator | Stable |
-| [Algorithmix](Algorithmix/README.md) | Creative prompt generator | Beta |
+| [JPrompt](JPrompt/JPrompt - README.md) | Journal prompt generator | Stable |
+| [OSlogan](OSlogan/OSlogan - README.md) | Random slogan generator | Stable |
+| [Algorithmix](Algorithmix/Algorithmix - README.md) | Creative prompt generator | Beta |
 
 ### Utilities
 | App | Description | Status |
 |-----|-------------|---------|
-| [HTML2MD](HTML2MD/README.md) | HTML to Markdown converter | Stable |
-| [Galleria](Galleria/README.md) | Base64 image gallery | Stable |
-| [Recordr](Recordr/README.md) | Simple audio recorder | Beta |
+| [HTML2MD](HTML2MD/HTML2MD - README.md) | HTML to Markdown converter | Stable |
+| [Galleria](Galleria/Galleria - README.md) | Base64 image gallery | Stable |
+| [Recordr](Recordr/Recordr - README.md) | Simple audio recorder | Beta |
 
 ## Technical Details
 
@@ -84,7 +84,7 @@ There is some customisation that can be done - but this should be a one time thi
 - Standardized theme system across apps
 
 ### Template System
-The [SAppTemplate](SAppTemplate/README.md) provides the foundation for all apps, ensuring consistency in:
+The [SAppTemplate](SAppTemplate/SAppTemplate - README.md) provides the foundation for all apps, ensuring consistency in:
 - Basic structure
 - Theme implementation
 - Common utilities


### PR DESCRIPTION
## Summary
- fix typo in README
- correct README links to app READMEs
- fix CounTally test script path handling
- add unit tests for CounTally HTML generators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842114e6a70832893d5c6439b1fcfcb